### PR TITLE
maven.imagej.net -> maven.scijava.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 branches:
   only:
   - master

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>23.2.0</version>
+		<version>26.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -134,14 +134,14 @@
 		<license.copyrightOwners>University of Basel, Switzerland</license.copyrightOwners>
 		<maven.source.skip>true</maven.source.skip>
 
-		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
-		<releaseProfiles>deploy-to-imagej</releaseProfiles>
+		<!-- NB: Deploy releases to the SciJava Maven repository. -->
+		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 	</properties>
 
 	<repositories>
 		<repository>
-			<id>imagej.public</id>
-			<url>http://maven.imagej.net/content/groups/public</url>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Achieved by running [ij-to-sj.sh](https://github.com/ctrueden/ctr-scripts/blob/master/one-offs/ij-to-sj.sh) on the root of this repository.

This should fix the Travis CI build.
