### PR TITLE
Use LUTs unambiguous to color blind humans

### DIFF
--- a/src/main/resources/scripts/Plugins/IMCF_Utilities/Display/Auto-Range_Contrast+LUT.ijm
+++ b/src/main/resources/scripts/Plugins/IMCF_Utilities/Display/Auto-Range_Contrast+LUT.ijm
@@ -1,5 +1,6 @@
 // use a channel order more common to microscopy images:
-LUTs = newArray("Blue", "Green", "Red", "Cyan", "Magenta", "Yellow");
+// use LUTs unambiguous to color blind humans.
+LUTs = newArray("CB Blue", "CB BluishGreen", "CB Orange", "CB ReddishPurple", "CB SkyBlue", "CB Yellow", "CB Vermilion");
 
 getDimensions(width, height, channels, slices, frames);
 


### PR DESCRIPTION
Addresses issue #137 in python-imcflibs

see https://github.com/imcf/python-imcflibs/issues/137